### PR TITLE
Add new seeders: eu.digibyteseed.com, testnet.digibyteseed.com, seed.digibyte.link, testnetseed.digibyte.link

### DIFF
--- a/README.md
+++ b/README.md
@@ -212,19 +212,19 @@ For an example of what you should be seeing, look at the results for seed.digiby
 STEP 6. SETUP DIGIBYTE SEEDER TO STARTUP AT BOOT
 ------------------------------------------------
 
-You can use the included seedstartup.sh script to automatically startup your DigiByte Seeder when your system boots.
+You can use the included startseeder.sh script to automatically startup your DigiByte Seeder when your system boots.
 
 Edit the script to add your DigiByte Seeder credentials:
 
-$ ```nano ~/digibyte-seeder/seedstart.sh```
+$ ```nano ~/digibyte-seeder/startseeder.sh```
 
 Save and exit. Copy the file to your home folder:
 
-$ ```cp ~/digibyte-seeder/seedstart.sh ~/```
+$ ```cp ~/digibyte-seeder/startseeder.sh ~/```
 
 Make it executable:
 
-$ ```sudo chmod +x ~/digibyte-seeder/seedstart.sh```
+$ ```sudo chmod +x ~/digibyte-seeder/startseeder.sh```
 
 Edit cron:
 
@@ -232,7 +232,7 @@ $ ```crontab -e```
 
 Add this value to the bottom of your cron file. Replace 'user' with your user account name.
 
-```@reboot sleep 30 && /home/user/seedstartup.sh```
+```@reboot sleep 30 && /home/user/startseeder.sh```
 
 When your server boots, it will pause for 30 seconds, before launching your DigiByte Seeder. Adjust the duration if needed. Save and exit.
 

--- a/README.md
+++ b/README.md
@@ -70,9 +70,9 @@ Ubuntu: $ ```sudo apt-get install gcc g++ build-essential libboost-all-dev libss
 
 Debian: $ ```apt-get install gcc g++ build-essential libboost-all-dev libssl-dev git tmux iptables```
 
-If running Debian, switch back to your user account ('username' in this example):
+If running Debian, switch back to your user account ('user' in this example):
 
-$ ```su username```
+$ ```su user```
 
 Clone the DigiByte Seeder software into your home folder:
 
@@ -177,7 +177,7 @@ Debian: $ ```/sbin/iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT -
 
 Debian: $ ```apt install iptables-persistent -Y```
 
-Debian: $ ```su username``` (switch back to your user account - 'username' in this example)
+Debian: $ ```su user``` (switch back to your user account - 'user' in this example)
 
 If properly configured, this will allow you to run dnsseed in userspace, using
 the ```-p 5353``` option. iptables-persistent is used to make the change stick after a reboot.
@@ -224,9 +224,9 @@ Edit cron:
 
 $ ```crontab -e```
 
-Add this value to the bottom of your cron file. Replace 'username' with your user account name.
+Add this value to the bottom of your cron file. Replace 'user' with your user account name.
 
-```@reboot sleep 30 && /home/username/seedstartup.sh```
+```@reboot sleep 30 && /home/user/seedstartup.sh```
 
 This will pause for 30 seconds at boot before launching your DigiByte Seeder. Adjust the duration if needed. Save and exit.
 

--- a/README.md
+++ b/README.md
@@ -122,11 +122,11 @@ $ ```tmux new -s dgbseeder```
 
 To run a mainnet seeder, enter:
 
-$ ```sudo ./dnsseed -h seed.example.com -n vps.example.com -m email.example.com -p 5353 -a 123.123.123.123```
+$ ```./dnsseed -h seed.example.com -n vps.example.com -m email.example.com -p 5353 -a 123.123.123.123```
 
 To run a testnet seeder, enter:
 
-$ ```sudo ./dnsseed -h seed.example.com -n vps.example.com -m email.example.com -p 5353 -a 123.123.123.123 --testnet```
+$ ```./dnsseed -h seed.example.com -n vps.example.com -m email.example.com -p 5353 -a 123.123.123.123 --testnet```
 
 - Subsitute ```seed.example.com``` with the NS Host record.
 - Subsitute ```vps.example.com``` with the A Host record.

--- a/README.md
+++ b/README.md
@@ -190,7 +190,7 @@ $ ```./dnsseed -h seed.example.com -n vps.example.com -a 123.123.123.123```
 
 ### Firewall
 
-Be sure to check that port 53 is open on any external firewalls as well.
+Be sure to check that port 53 is open on any external firewalls.
 
 If your system firewall is enabled, make sure you have opened port 53:
 

--- a/README.md
+++ b/README.md
@@ -190,12 +190,12 @@ $ ```./dnsseed -h seed.example.com -n vps.example.com -a 123.123.123.123```
 
 ### Firewall
 
-Be sure to check that port 53 is open on any external firewalls.
+Be sure to check that port 53 is open on any external firewall.
 
 If your system firewall is enabled, make sure you have opened port 53:
 
 $ ```sudo ufw allow 53```
 
-You can check the staus of your system firewall with:
+You can check the status of your system firewall with:
 
 $ ```sudo ufw status```

--- a/README.md
+++ b/README.md
@@ -61,11 +61,13 @@ $ ```su```
 Perform a system update:
 
 Ubuntu: $ ```sudo apt-get update```
+
 Debian: $ ```apt-get update```
 
 Install required software packages for DigiByte Seeder on Ubuntu or Debian:
 
 Ubuntu: $ ```sudo apt-get install gcc g++ build-essential libboost-all-dev libssl-dev git tmux iptables```
+
 Debian: $ ```apt-get install gcc g++ build-essential libboost-all-dev libssl-dev git tmux iptables```
 
 If running Debian, switch back to user account ('linuxuser' in this example):
@@ -157,7 +159,7 @@ When you need to reconnect to the tmux session later, enter:
 $ ```tmux a -t dgbseeder```
 
 
-OPEN PORTS WHEN RUNNING AS NON-ROOT
+MAP PORT 53 WHEN RUNNING AS NON-ROOT
 -----------------------------------
 
 Typically, you'll need root privileges to listen to port 53 (name service).
@@ -165,13 +167,13 @@ Typically, you'll need root privileges to listen to port 53 (name service).
 One solution is using an iptables rule (Linux only) to redirect it to
 a non-privileged port.
 
-Ubuntu:
-$ ```iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
+Ubuntu: $ ```iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
 
-On Debian:
-$ ```su```  (switch to root)
-$ ```/sbin/iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
-$ ```su linuxuser``` (switch back to user account)
+Debian: $ ```su```  (switch to root)
+
+Debian: $ ```/sbin/iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
+
+Debian: $ ```su linuxuser``` (switch back to user account)
 
 If properly configured, this will allow you to run dnsseed in userspace, using
 the ```-p 5353``` option.

--- a/README.md
+++ b/README.md
@@ -68,9 +68,9 @@ Ubuntu: $ ```sudo apt-get install gcc g++ build-essential libboost-all-dev libss
 
 Debian: $ ```apt-get install gcc g++ build-essential libboost-all-dev libssl-dev git tmux iptables```
 
-If running Debian, switch back to user account ('linuxuser' in this example):
+If running Debian, switch back to your user account ('username' in this example):
 
-$ ```su linuxuser```
+$ ```su username```
 
 Clone the DigiByte Seeder software into your home folder:
 
@@ -171,7 +171,7 @@ Debian: $ ```su```  (switch to root)
 
 Debian: $ ```/sbin/iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
 
-Debian: $ ```su linuxuser``` (switch back to user account)
+Debian: $ ```su username``` (switch back to your user account - 'username' in this example)
 
 If properly configured, this will allow you to run dnsseed in userspace, using
 the ```-p 5353``` option.

--- a/README.md
+++ b/README.md
@@ -70,9 +70,15 @@ If setting up a testnet node, you need to make a change to protocol.cpp:
 
 $ ```nano ~/digibyte-seeder/protocol.cpp```
 
-Change line 25 to: ```unsigned char pchMessageStart[4] = { 0xfd, 0xc8, 0xbd, 0xdd };```
+Change line 25 to: ```unsigned char pchMessageStart[4] = { 0xfd, 0xc8, 0xbd, 0xdd };``` 
 
-Compile the software:
+If you are also running a DigiByte full node on the same server, you need to make a change to main.cpp to add the loopback IP address:
+
+$ ```nano ~/digibyte-seeder/main.cpp```
+
+Change line 424 and 425 to add the loopback IP address: ```"127.0.0.1", ```. This will make it possible for the Seeder to connect directly to your local DigiByte full node.
+
+To compile the software:
 
 $ ```cd ~/digibyte-seeder```
 
@@ -124,7 +130,7 @@ $ ```sudo ./dnsseed -h seed.example.com -n vps.example.com -m email.example.com 
 
 - Subsitute ```seed.example.com``` with the NS Host record.
 - Subsitute ```vps.example.com``` with the A Host record.
-- Subsitute ```email.example.com``` with an email address that you can be reached at for the SOA records, substituting the @ for a period. So youremail@example.com would be youremail.example.com. [This can be omitted if desired - remove ```-m  email.example.com``` from the command.]
+- Subsitute ```email.example.com``` with an email address that you can be reached at for the SOA records, substituting the @ for a period. So youremail@example.com would be youremail.example.com.
 - Subsitute ```123.123.123.123``` with IP address of your VPS from Step 1.
 - If you are running testnet seeder, note that you must include the ```--testnet``` flag.
 
@@ -154,7 +160,7 @@ For an example of what you should be seeing, look at the results for seed.digiby
 TROUBLESHOOTING
 --------------
 
-### Running a Non-Root
+### Running as Non-Root
 
 Typically, you'll need root privileges to listen to port 53 (name service).
 
@@ -165,6 +171,10 @@ $ ```iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353`
 
 If properly configured, this will allow you to run dnsseed in userspace, using
 the ```-p 5353``` option.
+
+You can make this change persistent with:
+
+$ ```sudo apt-get install iptables-persistent```
 
 Another solution is allowing a binary to bind to ports < 1024 with setcap (IPv6 access-safe)
 
@@ -180,8 +190,12 @@ $ ```./dnsseed -h seed.example.com -n vps.example.com -a 123.123.123.123```
 
 ### Firewall
 
-If you are still having a problem, try opening ports 53 and 5353 on your firewall:
+Be sure to check that port 53 is open on any external firewalls as well.
 
-$ ```sudo ufw allow 5353```
+If your system firewall is enabled, make sure you have opened port 53:
 
 $ ```sudo ufw allow 53```
+
+You can check the staus of your system firewall with:
+
+$ ```sudo ufw status```

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ REQUIREMENTS
 
 To setup a DigiByte Seeder you need:
 
-- A server to run it on. A VPS is fine. It does not need many resources - DigiByte Seeder needs <1Gb RAM to run.
+- A server to run it on with a static IP address. A VPS is fine. It does not need many resources - DigiByte Seeder needs <1Gb RAM to run.
 - A domain name where you can edit the DNS settings.
 
 # HOW TO SETUP A DIGIBYTE SEEDER

--- a/README.md
+++ b/README.md
@@ -16,8 +16,16 @@ JOIN DIGIBYTE CRITICAL INFRASTRUCTURE TEAM (DGBCIT)
 
 If you are intending to run a DigiByte Seeder, you are encouraged to join the [DGBCIT Telegram group](https://t.me/DGBCIT). The DigiByte Critical Infrastructure Team helps coordinate the seeders on the network. The team provides a detailed step-by-step tutorial for setting up your DigiByte Seeder and community support if you need help. Participation is optional but encouraged. Find the detailed tutorial [here](https://www.evernote.com/shard/s20/client/snv?noteGuid=46de28c1-9066-4ca5-8048-6f29f9e3bf52&noteKey=66077e0b3f969350ebefe4228d731425&sn=https%3A%2F%2Fwww.evernote.com%2Fshard%2Fs20%2Fsh%2F46de28c1-9066-4ca5-8048-6f29f9e3bf52%2F66077e0b3f969350ebefe4228d731425&title=Setting%2Bup%2Ba%2BDigiByte%2BSeeder). 
 
+The objectives of DGBCIT is to help:
+
+* Distribute DigiByte Seeders across the community.
+* Distribute the Seeders geographically across the globe.
+* Distribute DigiByte Seeders across diferent providers.
+
 REQUIREMENTS
 ------------
+
+To improve decentralization, and mitigate single points of failure, it is requested that each person only run one mainnet seeder each. Some people can also run a testnet seeeder but we need less of those.
 
 To setup a DigiByte Seeder you need:
 

--- a/README.md
+++ b/README.md
@@ -50,9 +50,7 @@ Expected response: ```vps.example.com.   161    IN      A     123.123.123.123```
 COMPILE SOFTWARE
 ----------------
 
-These instructions are or Ubuntu or Debian. 
-
-Compiling will require boost and ssl.  On debian systems, these are provided by `libboost-dev` and `libssl-dev` respectively. 
+These instructions are for Ubuntu or Debian. Compiling will require boost and ssl.  On debian systems, these are provided by `libboost-dev` and `libssl-dev` respectively. 
 
 If running Debian, switch to root:
 

--- a/README.md
+++ b/README.md
@@ -165,7 +165,7 @@ Typically, you'll need root privileges to listen to port 53 (name service).
 One solution is using an iptables rule (Linux only) to redirect it to
 a non-privileged port.
 
-Ubuntu: $ ```iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
+Ubuntu: $ ```sudo iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
 
 Debian: $ ```su```  (switch to root)
 

--- a/README.md
+++ b/README.md
@@ -167,18 +167,20 @@ a non-privileged port.
 
 Ubuntu: $ ```sudo iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
 
+Ubuntu: $ ```sudo apt-get install iptables-persistent -Y```
+
 Debian: $ ```su```  (switch to root)
 
 Debian: $ ```/sbin/iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
 
+Debian: $ ```apt install iptables-persistent -Y```
+
 Debian: $ ```su username``` (switch back to your user account - 'username' in this example)
 
 If properly configured, this will allow you to run dnsseed in userspace, using
-the ```-p 5353``` option.
+the ```-p 5353``` option. iptables-persistent is used to make the change stick after a reboot.
 
-You can make this change persistent with:
 
-$ ```sudo apt-get install iptables-persistent -Y```
 
 Another solution is allowing a binary to bind to ports < 1024 with setcap (IPv6 access-safe)
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,9 @@ Visit your domain name registrar and edit the DNS settings. Assuming you want to
 Create an NS record:
 
 - Host:     ```seed.example.com``` or ```testnetseed.example.com```       [ The desired address of your DigiByte Seeder. ]
-- Answer:   ```server.example.com```                                      [ A subdomain to identify your Server. ] 
+- Answer:   ```server.example.com```                                      [ A subdomain to identify your server. ] 
+
+Note: Some providers do not allow you to add an NS record. You may need to move your domain to one that does, or setup a new one.
 
 Create an A record:
 

--- a/README.md
+++ b/README.md
@@ -50,15 +50,27 @@ Expected response: ```vps.example.com.   161    IN      A     123.123.123.123```
 COMPILE SOFTWARE
 ----------------
 
-Compiling will require boost and ssl.  On debian systems, these are provided by `libboost-dev` and `libssl-dev` respectively.
+These instructions are or Ubuntu or Debian. 
+
+Compiling will require boost and ssl.  On debian systems, these are provided by `libboost-dev` and `libssl-dev` respectively. 
+
+If running Debian, switch to root:
+
+$ ```su```
 
 Perform a system update:
 
-$ ```sudo apt-get update```
+Ubuntu: $ ```sudo apt-get update```
+Debian: $ ```apt-get update```
 
-Install the software packages needed to compile the DigiByte Seeder:
+Install required software packages for DigiByte Seeder on Ubuntu or Debian:
 
-$ ```sudo apt-get install gcc g++ build-essential libboost-all-dev libssl-dev```
+Ubuntu: $ ```sudo apt-get install gcc g++ build-essential libboost-all-dev libssl-dev git tmux iptables```
+Debian: $ ```apt-get install gcc g++ build-essential libboost-all-dev libssl-dev git tmux iptables```
+
+If running Debian, switch back to user account ('linuxuser' in this example):
+
+$ ```su linuxuser```
 
 Clone the DigiByte Seeder software into your home folder:
 
@@ -144,6 +156,35 @@ When you need to reconnect to the tmux session later, enter:
 
 $ ```tmux a -t dgbseeder```
 
+
+OPEN PORTS WHEN RUNNING AS NON-ROOT
+-----------------------------------
+
+Typically, you'll need root privileges to listen to port 53 (name service).
+
+One solution is using an iptables rule (Linux only) to redirect it to
+a non-privileged port.
+
+Ubuntu:
+$ ```iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
+
+On Debian:
+$ ```su```  (switch to root)
+$ ```/sbin/iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
+$ ```su linuxuser``` (switch back to user account)
+
+If properly configured, this will allow you to run dnsseed in userspace, using
+the ```-p 5353``` option.
+
+You can make this change persistent with:
+
+$ ```sudo apt-get install iptables-persistent -Y```
+
+Another solution is allowing a binary to bind to ports < 1024 with setcap (IPv6 access-safe)
+
+$ ```setcap 'cap_net_bind_service=+ep' /path/to/dnsseed```
+
+
 TEST DIGIBYTE SEEDER
 --------------------
 
@@ -159,26 +200,6 @@ For an example of what you should be seeing, look at the results for seed.digiby
 
 TROUBLESHOOTING
 --------------
-
-### Running as Non-Root
-
-Typically, you'll need root privileges to listen to port 53 (name service).
-
-One solution is using an iptables rule (Linux only) to redirect it to
-a non-privileged port:
-
-$ ```iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
-
-If properly configured, this will allow you to run dnsseed in userspace, using
-the ```-p 5353``` option.
-
-You can make this change persistent with:
-
-$ ```sudo apt-get install iptables-persistent```
-
-Another solution is allowing a binary to bind to ports < 1024 with setcap (IPv6 access-safe)
-
-$ ```setcap 'cap_net_bind_service=+ep' /path/to/dnsseed```
 
 ### Running under Ubuntu
 

--- a/README.md
+++ b/README.md
@@ -24,6 +24,8 @@ To setup a DigiByte Seeder you need:
 - A server to run it on with a static IP address. A VPS is fine. It does not need many resources - DigiByte Seeder needs <1Gb RAM to run.
 - A domain name where you can edit the DNS settings.
 
+Note: Many VPS providers give you the option to chose from several geographic locations in which to run your server. To help better distribute the DigiByte Seeders around the globe, please try and choose a location where the network doesn't already have a Seeder, and a good distance from any existing seeders. Feel free to discuss this in the [DGBCIT Telegram group](https://t.me/DGBCIT) to help choose a good location.
+
 # HOW TO SETUP A DIGIBYTE SEEDER
 
 STEP 1. SETUP DNS RECORDS

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Create an NS record:
 - Host:     ```seed.example.com``` or ```testnetseed.example.com```       [ The desired address of your DigiByte Seeder. ]
 - Answer:   ```server.example.com```                                      [ A subdomain to identify your server. ] 
 
-Note: Some providers do not allow you to add an NS record. You may need to move your domain to one that does, or setup a new one.
+Note: Some providers do not allow you to add an NS record. In that case, you may need to move your domain to one that does, or register a new one.
 
 Create an A record:
 
@@ -91,12 +91,6 @@ Clone the DigiByte Seeder software into your home folder:
 $ ```cd ~/```
 
 $ ```git clone https://github.com/DigiByte-Core/digibyte-seeder```
-
-If setting up a testnet node, you need to make a change to protocol.cpp:
-
-$ ```nano ~/digibyte-seeder/protocol.cpp```
-
-Change line 25 to: ```unsigned char pchMessageStart[4] = { 0xfd, 0xc8, 0xbd, 0xdd };``` 
 
 If you are also running a DigiByte full node on the same server, you need to make a change to main.cpp to add the loopback IP address:
 

--- a/README.md
+++ b/README.md
@@ -25,14 +25,12 @@ The objectives of DGBCIT is to help:
 REQUIREMENTS
 ------------
 
-To improve decentralization, and mitigate single points of failure, it is requested that each person only run one mainnet seeder each. Some people can also run a testnet seeeder but we need less of those.
+**IMPORTANT**: To improve decentralization, mitigate single points of failure, and increase community participation, it is recommended that each person run a maximum of one mainnet seeder and one testnet seeder each. The network does not require many testnet seeders, so only a few people need run them.
 
 To setup a DigiByte Seeder you need:
 
-- A server to run it on with a static IP address. A VPS is fine. It does not need many resources - DigiByte Seeder needs <1Gb RAM to run.
+- A server to run it on with a static IP address. A VPS is fine. It does not need many resources - DigiByte Seeder needs <1Gb RAM to run. Note: Many VPS providers give you the option to chose from several geographic locations in which to run your server. To help better distribute the DigiByte Seeders around the globe, please try and choose a location where the network doesn't already have a Seeder, that is a good distance from any existing seeders. Feel free to discuss this in the [DGBCIT Telegram group](https://t.me/DGBCIT) to help choose a good location.
 - A domain name where you can edit the DNS settings.
-
-Note: Many VPS providers give you the option to chose from several geographic locations in which to run your server. To help better distribute the DigiByte Seeders around the globe, please try and choose a location where the network doesn't already have a Seeder, and a good distance from any existing seeders. Feel free to discuss this in the [DGBCIT Telegram group](https://t.me/DGBCIT) to help choose a good location.
 
 # HOW TO SETUP A DIGIBYTE SEEDER
 

--- a/README.md
+++ b/README.md
@@ -181,13 +181,13 @@ a non-privileged port.
 
 Ubuntu: $ ```sudo iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
 
-Ubuntu: $ ```sudo apt-get install iptables-persistent -Y```
+Ubuntu: $ ```sudo apt-get install iptables-persistent -y```
 
 Debian: $ ```su```  (switch to root)
 
 Debian: $ ```/sbin/iptables -t nat -A PREROUTING -p udp --dport 53 -j REDIRECT --to-port 5353```
 
-Debian: $ ```apt install iptables-persistent -Y```
+Debian: $ ```apt install iptables-persistent -y```
 
 Debian: $ ```su user``` (switch back to your user account - 'user' in this example)
 

--- a/README.md
+++ b/README.md
@@ -16,8 +16,10 @@ JOIN DIGIBYTE CRITICAL INFRASTRUCTURE TEAM (DGBCIT)
 
 If you are intending to run a DigiByte Seeder, you are encouraged to join the [DGBCIT Telegram group](https://t.me/DGBCIT). The DigiByte Critical Infrastructure Team helps coordinate the seeders on the network. The team provides a detailed step-by-step tutorial for setting up your DigiByte Seeder and community support if you need help. Participation is optional but encouraged. Find the detailed tutorial [here](https://www.evernote.com/shard/s20/client/snv?noteGuid=46de28c1-9066-4ca5-8048-6f29f9e3bf52&noteKey=66077e0b3f969350ebefe4228d731425&sn=https%3A%2F%2Fwww.evernote.com%2Fshard%2Fs20%2Fsh%2F46de28c1-9066-4ca5-8048-6f29f9e3bf52%2F66077e0b3f969350ebefe4228d731425&title=Setting%2Bup%2Ba%2BDigiByte%2BSeeder). 
 
-SETUP DNS RECORDS
------------------
+# SETUP A DIGIBYTE SEEDER
+
+STEP 1. SETUP DNS RECORDS
+-------------------------
 
 You need to use a domain name where you have access to the DNS settings. Assuming you want to run a DNS seed on seed.example.com, you will need an authorative NS record in example.com's domain record, pointing to for example vps.example.com. You will aslo need an A record for vps.example.com pointing at the IP address of the VPS.
 
@@ -47,8 +49,8 @@ Expected response: ```vps.example.com.   161    IN      A     123.123.123.123```
 
 (It should return the IP address of your VPS.)
 
-COMPILE SOFTWARE
-----------------
+STEP 2. COMPILE SOFTWARE
+------------------------
 
 These instructions are for Ubuntu or Debian. Compiling will require boost and ssl.  On debian systems, these are provided by `libboost-dev` and `libssl-dev` respectively. 
 
@@ -98,8 +100,8 @@ $ ```make```
 
 This will produce the `dnsseed` binary.
 
-START DIGIBYTE SEEDER
----------------------
+STEP 3. START DIGIBYTE SEEDER
+-----------------------------
 
 To view the software flag options, enter:
 
@@ -157,8 +159,8 @@ When you need to reconnect to the tmux session later, enter:
 $ ```tmux a -t dgbseeder```
 
 
-MAP PORT 53 WHEN RUNNING AS NON-ROOT
------------------------------------
+STEP 4. MAP PORT 53 WHEN RUNNING AS NON-ROOT
+--------------------------------------------
 
 Typically, you'll need root privileges to listen to port 53 (name service).
 
@@ -187,8 +189,8 @@ Another solution is allowing a binary to bind to ports < 1024 with setcap (IPv6 
 $ ```setcap 'cap_net_bind_service=+ep' /path/to/dnsseed```
 
 
-TEST DIGIBYTE SEEDER
---------------------
+STEP 5. TEST DIGIBYTE SEEDER
+----------------------------
 
 To verify that your DigiByte Seeder is setup correctly, open a web browser and visit:
 
@@ -199,6 +201,7 @@ Enter the domain you chose for your seeder. You should see a list of IP addresse
 For an example of what you should be seeing, look at the results for seed.digibyte.org here:
 
 [https://www.whatsmydns.net/#A/seed.digibyte.org](https://www.whatsmydns.net/#A/seed.digibyte.org)
+
 
 TROUBLESHOOTING
 --------------

--- a/README.md
+++ b/README.md
@@ -16,38 +16,46 @@ JOIN DIGIBYTE CRITICAL INFRASTRUCTURE TEAM (DGBCIT)
 
 If you are intending to run a DigiByte Seeder, you are encouraged to join the [DGBCIT Telegram group](https://t.me/DGBCIT). The DigiByte Critical Infrastructure Team helps coordinate the seeders on the network. The team provides a detailed step-by-step tutorial for setting up your DigiByte Seeder and community support if you need help. Participation is optional but encouraged. Find the detailed tutorial [here](https://www.evernote.com/shard/s20/client/snv?noteGuid=46de28c1-9066-4ca5-8048-6f29f9e3bf52&noteKey=66077e0b3f969350ebefe4228d731425&sn=https%3A%2F%2Fwww.evernote.com%2Fshard%2Fs20%2Fsh%2F46de28c1-9066-4ca5-8048-6f29f9e3bf52%2F66077e0b3f969350ebefe4228d731425&title=Setting%2Bup%2Ba%2BDigiByte%2BSeeder). 
 
-# SETUP A DIGIBYTE SEEDER
+REQUIREMENTS
+------------
+
+To setup a DigiByte Seeder you need:
+
+- A server to run it on. A VPS is fine. It does not need many resources - DigiByte Seeder needs <1Gb RAM to run.
+- A domain name where you can edit the DNS settings.
+
+# HOW TO SETUP A DIGIBYTE SEEDER
 
 STEP 1. SETUP DNS RECORDS
 -------------------------
 
-You need to use a domain name where you have access to the DNS settings. Assuming you want to run a DNS seed on seed.example.com, you will need an authorative NS record in example.com's domain record, pointing to for example vps.example.com. You will aslo need an A record for vps.example.com pointing at the IP address of the VPS.
+Visit your domain name registrar and edit the DNS settings. Assuming you want to run a DNS seed on seed.example.com, you will need an authorative NS record in example.com's domain record, pointing to a subdomain to identify your server - e.g. server.example.com. You will also need an A record for server.example.com pointing at the IP address of the server.
 
 Create an NS record:
 
-- Host:     ```seed.example.com``` or ```testnetseed.example.com```  [ The desired address of your DigiByte Seeder. ]
-- Answer:   ```vps.example.com```                                         [ A URL to identify your VPS. ] 
+- Host:     ```seed.example.com``` or ```testnetseed.example.com```       [ The desired address of your DigiByte Seeder. ]
+- Answer:   ```server.example.com```                                      [ A subdomain to identify your Server. ] 
 
 Create an A record:
 
-- Host:     ```vps.example.com```                                        [ Use the same name you set above. ]
-- Answer:   ```123.123.123.123```                                           [ The IP address of your VPS. ] 
+- Host:     ```server.example.com```                                      [ Use the same subdomain you set above. ]
+- Answer:   ```123.123.123.123```                                         [ The IP address of your server. ] 
 
 Test the NS record:
 
 $ ```dig -t NS seed.example.com```
 
-Expected response: ```seed.example.com.   21600    IN      NS     vps.example.com.```
+Expected response: ```seed.example.com.   21600    IN      NS     server.example.com.```
 
-(It should return the URL you chose to identify your VPS.)
+(It should return the URL you chose to identify your server - e.g. server.example.com.)
 
 Test the A record:
 
-$ ```dig -t A vps.example.com```
+$ ```dig -t A server.example.com```
 
-Expected response: ```vps.example.com.   161    IN      A     123.123.123.123```
+Expected response: ```server.example.com.   161    IN      A     123.123.123.123```
 
-(It should return the IP address of your VPS.)
+(It should return the IP address of your server.)
 
 STEP 2. COMPILE SOFTWARE
 ------------------------
@@ -136,16 +144,16 @@ $ ```tmux new -s dgbseeder```
 
 To run a mainnet seeder, enter:
 
-$ ```./dnsseed -h seed.example.com -n vps.example.com -m email.example.com -p 5353 -a 123.123.123.123```
+$ ```./dnsseed -h seed.example.com -n server.example.com -m email.example.com -p 5353 -a 123.123.123.123```
 
 To run a testnet seeder, enter:
 
-$ ```./dnsseed -h seed.example.com -n vps.example.com -m email.example.com -p 5353 -a 123.123.123.123 --testnet```
+$ ```./dnsseed -h seed.example.com -n server.example.com -m email.example.com -p 5353 -a 123.123.123.123 --testnet```
 
 - Subsitute ```seed.example.com``` with the NS Host record.
-- Subsitute ```vps.example.com``` with the A Host record.
-- Subsitute ```email.example.com``` with an email address that you can be reached at for the SOA records, substituting the @ for a period. So youremail@example.com would be youremail.example.com.
-- Subsitute ```123.123.123.123``` with IP address of your VPS from Step 1.
+- Subsitute ```server.example.com``` with the A Host record.
+- Subsitute ```youremail.example.com``` with an email address that you can be reached at for the SOA records, substituting the @ for a period. So youremail@example.com would be youremail.example.com.
+- Subsitute ```123.123.123.123``` with IP address of your Server from Step 1.
 - If you are running testnet seeder, note that you must include the ```--testnet``` flag.
 
 The software will begin crawling the DigiByte network. You may need to wait or minute or two to see results coming in. Check that the available count is climbing. This is a good sign that it is working correctly.
@@ -196,7 +204,7 @@ To verify that your DigiByte Seeder is setup correctly, open a web browser and v
 
 [https://www.whatsmydns.net/#A/](https://www.whatsmydns.net/#A/)
 
-Enter the domain you chose for your seeder. You should see a list of IP addresses returned for each location.
+Enter the address you chose for your Seeder. You should see a list of IP addresses returned for each location.
 
 For an example of what you should be seeing, look at the results for seed.digibyte.org here:
 
@@ -208,7 +216,7 @@ STEP 6. SETUP DIGIBYTE SEEDER TO STARTUP AT BOOT
 
 You can use the included seedstartup.sh script to automatically startup your DigiByte Seeder when your system boots.
 
-Edit the script to include your server URLs and IP address:
+Edit the script to add your DigiByte Seeder credentials:
 
 $ ```nano ~/digibyte-seeder/seedstart.sh```
 
@@ -228,7 +236,7 @@ Add this value to the bottom of your cron file. Replace 'user' with your user ac
 
 ```@reboot sleep 30 && /home/user/seedstartup.sh```
 
-This will pause for 30 seconds at boot before launching your DigiByte Seeder. Adjust the duration if needed. Save and exit.
+When your server boots, it will pause for 30 seconds, before launching your DigiByte Seeder. Adjust the duration if needed. Save and exit.
 
 
 TROUBLESHOOTING
@@ -240,7 +248,7 @@ All Ubuntu releases from 16.10 onwards come installed with systemd-resolved, whi
 
 The recommended solution is to bind the seeder to a specific IP address
 
-$ ```./dnsseed -h seed.example.com -n vps.example.com -a 123.123.123.123```
+$ ```./dnsseed -h seed.example.com -n server.example.com -a 123.123.123.123```
 
 ### Firewall
 

--- a/README.md
+++ b/README.md
@@ -226,7 +226,7 @@ $ ```crontab -e```
 
 Add this value to the bottom of your cron file. Replace 'username' with your user account name.
 
-```@reboot sleep 30 & /home/username/seedstartup.sh```
+```@reboot sleep 30 && /home/username/seedstartup.sh```
 
 This will pause for 30 seconds at boot before launching your DigiByte Seeder. Adjust the duration if needed. Save and exit.
 

--- a/README.md
+++ b/README.md
@@ -203,6 +203,34 @@ For an example of what you should be seeing, look at the results for seed.digiby
 [https://www.whatsmydns.net/#A/seed.digibyte.org](https://www.whatsmydns.net/#A/seed.digibyte.org)
 
 
+STEP 6. SETUP DIGIBYTE SEEDER TO STARTUP AT BOOT
+------------------------------------------------
+
+You can use the included seedstartup.sh script to automatically startup your DigiByte Seeder when your system boots.
+
+Edit the script to include your server URLs and IP address:
+
+$ ```nano ~/digibyte-seeder/seedstart.sh```
+
+Save and exit. Copy the file to your home folder:
+
+$ ```cp ~/digibyte-seeder/seedstart.sh ~/```
+
+Make it executable:
+
+$ ```sudo chmod +x ~/digibyte-seeder/seedstart.sh```
+
+Edit cron:
+
+$ ```crontab -e```
+
+Add this value to the bottom of your cron file. Replace 'username' with your user account name.
+
+```@reboot sleep 30 & /home/username/seedstartup.sh```
+
+This will pause for 30 seconds at boot before launching your DigiByte Seeder. Adjust the duration if needed. Save and exit.
+
+
 TROUBLESHOOTING
 --------------
 

--- a/main.cpp
+++ b/main.cpp
@@ -421,8 +421,10 @@ extern "C" void* ThreadStats(void*) {
   return nullptr;
 }
 
-static const string mainnet_seeds[] = {"seed.digibyte.io", "seed.digibyte.org", "seed.digibyteblockchain.org", "seed.digibyte.help", "nl.digibyteseed.com", ""};
-static const string testnet_seeds[] = {"testseed.digibyteblockchain.org", "testnetseed.digibyte.help", ""};
+// The current list of DigiByte Seeders and who maintains them can be found pinned to the top of the DGBCIT Telegram group: https://t.me/DGBCIT
+
+static const string mainnet_seeds[] = {"seed.digibyte.io", "seed.digibyte.org", "seed.digibyteblockchain.org", "seed.digibyte.help", "nl.digibyteseed.com", "seed.digibytefoundation.io", ""};
+static const string testnet_seeds[] = {"testseed.digibyteblockchain.org", "testnetseed.digibyte.help", "testnet.digibyteseed.com", "testnetseed.digibytefoundation.io", ""};
 static const string *seeds = mainnet_seeds;
 
 extern "C" void* ThreadSeeder(void*) {

--- a/main.cpp
+++ b/main.cpp
@@ -421,8 +421,8 @@ extern "C" void* ThreadStats(void*) {
   return nullptr;
 }
 
-static const string mainnet_seeds[] = {"127.0.0.1", "seed.digibyte.io", "seed.digibyte.org", "seed.digibyteblockchain.org", "seed.digibyte.help", ""};
-static const string testnet_seeds[] = {"127.0.0.1", "testseed.digibyteblockchain.org", "86.175.202.63",  "47.75.38.245", "45.76.235.153", "24.101.88.154", "testnetseed.digibyte.help", ""};
+static const string mainnet_seeds[] = {"seed.digibyte.io", "seed.digibyte.org", "seed.digibyteblockchain.org", "seed.digibyte.help", "nl.digibyteseed.com", ""};
+static const string testnet_seeds[] = {"testseed.digibyteblockchain.org", "testnetseed.digibyte.help", ""};
 static const string *seeds = mainnet_seeds;
 
 extern "C" void* ThreadSeeder(void*) {

--- a/main.cpp
+++ b/main.cpp
@@ -423,8 +423,8 @@ extern "C" void* ThreadStats(void*) {
 
 // The current list of DigiByte Seeders and who maintains them can be found pinned to the top of the DGBCIT Telegram group: https://t.me/DGBCIT
 
-static const string mainnet_seeds[] = {"seed.digibyte.io", "seed.digibyte.org", "seed.digibyteblockchain.org", "seed.digibyte.help", "eu.digibyteseed.com", ""};
-static const string testnet_seeds[] = {"testseed.digibyteblockchain.org", "testnetseed.digibyte.help", "testnet.digibyteseed.com", ""};
+static const string mainnet_seeds[] = {"seed.digibyte.io", "seed.digibyte.org", "seed.digibyteblockchain.org", "seed.digibyte.help", "eu.digibyteseed.com", "seed.digibyte.link", ""};
+static const string testnet_seeds[] = {"testseed.digibyteblockchain.org", "testnetseed.digibyte.help", "testnet.digibyteseed.com", "testnetseed.digibyte.link", ""};
 static const string *seeds = mainnet_seeds;
 
 extern "C" void* ThreadSeeder(void*) {

--- a/main.cpp
+++ b/main.cpp
@@ -423,8 +423,8 @@ extern "C" void* ThreadStats(void*) {
 
 // The current list of DigiByte Seeders and who maintains them can be found pinned to the top of the DGBCIT Telegram group: https://t.me/DGBCIT
 
-static const string mainnet_seeds[] = {"seed.digibyte.io", "seed.digibyte.org", "seed.digibyteblockchain.org", "seed.digibyte.help", "nl.digibyteseed.com", "seed.digibytefoundation.io", ""};
-static const string testnet_seeds[] = {"testseed.digibyteblockchain.org", "testnetseed.digibyte.help", "testnet.digibyteseed.com", "testnetseed.digibytefoundation.io", ""};
+static const string mainnet_seeds[] = {"seed.digibyte.io", "seed.digibyte.org", "seed.digibyteblockchain.org", "seed.digibyte.help", "eu.digibyteseed.com", ""};
+static const string testnet_seeds[] = {"testseed.digibyteblockchain.org", "testnetseed.digibyte.help", "testnet.digibyteseed.com", ""};
 static const string *seeds = mainnet_seeds;
 
 extern "C" void* ThreadSeeder(void*) {

--- a/seedstartup.sh
+++ b/seedstartup.sh
@@ -1,0 +1,28 @@
+#  DigiByte Seeder Autostart Script
+#------------------------
+#  Place in the home directory
+#  chmod +x /home/user/seedstartup.sh
+#------------------------
+#  crontab -e
+#  @reboot /home/user/seedstartup.sh
+#  **************_Script_**************
+
+#!/bin/sh
+
+SESSION="dgbseeder"
+SESSIONEXISTS=$(tmux list-sessions | grep $SESSION)
+if [ ! -d "digibyte-seeder/" ]; then
+  echo "Error: digibyte-seeder directory not found. Place seedstartup.sh in your home directory!"
+  exit 1
+fi
+if [ "$SESSIONEXISTS" = "" ]
+then
+    tmux new-session -d -s $SESSION
+    tmux rename-window -t 0 'dgbseeder'
+    tmux send-keys -t 'dgbseeder' '' C-m 'cd digibyte-seeder' C-m clear C-m './dnsseed -h seed.example.com -n server.example.com -m email.example.com -p 5353 -a 123.123.123.123' C-m
+    tmux ls
+else
+  echo "Tmux session active! Open it with ´tmux a -t dgbseeder´"
+fi
+
+#  **************_Script_**************

--- a/seedstartup.sh
+++ b/seedstartup.sh
@@ -4,10 +4,29 @@
 #  chmod +x /home/user/seedstartup.sh
 #------------------------
 #  crontab -e
-#  @reboot /home/user/seedstartup.sh
+#  @reboot sleep 30 & /home/user/seedstartup.sh
 #  **************_Script_**************
 
 #!/bin/sh
+
+# ==============================================================
+
+# Add your Digibyte Seeder credentials here:
+
+# This is the host URL e.g. seed.example.com
+SEEDER_ADDRESS=seed.example.com
+
+# This is the subdomain to identify your server e.g. seed.example.com
+SEEDER_SERVER=server.example.com
+
+# This is the SOA email. Replace the @ with a . so youremail@example.com become youremail.example.com
+SEEDER_EMAIL=youremail.example.com
+
+# The IP address of the server running your seeder
+SEEDER_SERVER_IP=123.123.123.123
+
+# ==============================================================
+
 
 SESSION="dgbseeder"
 SESSIONEXISTS=$(tmux list-sessions | grep $SESSION)
@@ -19,7 +38,7 @@ if [ "$SESSIONEXISTS" = "" ]
 then
     tmux new-session -d -s $SESSION
     tmux rename-window -t 0 'dgbseeder'
-    tmux send-keys -t 'dgbseeder' '' C-m 'cd digibyte-seeder' C-m clear C-m './dnsseed -h seed.example.com -n server.example.com -m email.example.com -p 5353 -a 123.123.123.123' C-m
+    tmux send-keys -t 'dgbseeder' '' C-m 'cd digibyte-seeder' C-m clear C-m "./dnsseed -h ${SEEDER_ADDRESS} -n ${SEEDER_SERVER} -m ${SEEDER_EMAIL} -p 5353 -a ${SEEDER_SERVER_IP}" C-m
     tmux ls
 else
   echo "Tmux session active! Open it with ´tmux a -t dgbseeder´"

--- a/seedstartup.sh
+++ b/seedstartup.sh
@@ -4,7 +4,7 @@
 #  chmod +x /home/user/seedstartup.sh
 #------------------------
 #  crontab -e
-#  @reboot sleep 30 & /home/user/seedstartup.sh
+#  @reboot sleep 30 && /home/user/seedstartup.sh
 #  **************_Script_**************
 
 #!/bin/sh
@@ -13,10 +13,10 @@
 
 # Add your Digibyte Seeder credentials here:
 
-# This is the host URL e.g. seed.example.com
+# This is the address of your seeder e.g. seed.example.com
 SEEDER_ADDRESS=seed.example.com
 
-# This is the subdomain to identify your server e.g. seed.example.com
+# This is the subdomain to identify your server e.g. server.example.com
 SEEDER_SERVER=server.example.com
 
 # This is the SOA email. Replace the @ with a . so youremail@example.com become youremail.example.com

--- a/startseeder.sh
+++ b/startseeder.sh
@@ -1,10 +1,10 @@
 #  DigiByte Seeder Autostart Script
 #------------------------
 #  Place in the home directory
-#  chmod +x /home/user/seedstartup.sh
+#  chmod +x /home/user/startseeder.sh
 #------------------------
 #  crontab -e
-#  @reboot sleep 30 && /home/user/seedstartup.sh
+#  @reboot sleep 30 && /home/user/startseeder.sh
 #  **************_Script_**************
 
 #!/bin/sh
@@ -31,7 +31,7 @@ SEEDER_SERVER_IP=123.123.123.123
 SESSION="dgbseeder"
 SESSIONEXISTS=$(tmux list-sessions | grep $SESSION)
 if [ ! -d "digibyte-seeder/" ]; then
-  echo "Error: digibyte-seeder directory not found. Place seedstartup.sh in your home directory!"
+  echo "Error: digibyte-seeder directory not found. Place startseeder.sh in your home directory!"
   exit 1
 fi
 if [ "$SESSIONEXISTS" = "" ]


### PR DESCRIPTION
- Remove loopback IPs by default. Instructions now explain how to add them if needed when running a full node on the same system.
- Improvements to documentation including reminding user to unblock port 53 on an external firewall.
- Remove testnet full node IP addresses. These were temporarily added since we had no working Seeders for testnet until recently.

The new seeders list is [here](https://onedrive.live.com/view.aspx?resid=7280E5EDD22CC6C4!4870&ithint=file%2cdocx&authkey=!AJ1dKLXo0Q9pd6w). More DigiByte Seeders are on their way.

We are trying to add seeders distributed around the world. US and EU now have two each. It would be great to get some added in Asia, Africa and Australia/NZ so we have broad global coverage. There is hopefully one being set up in Australia at the moment.